### PR TITLE
style: Run cargo fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,5 +457,4 @@ apps/ @octocat
             Some(&vec![Owner::Username("@doug".into())])
         )
     }
-
 }


### PR DESCRIPTION
* Run `cargo fmt`

This will repair the Travis CI build. Not sure if you intend to supersede Travis CI with GitHub Actions (I noticed c9606413cea99166fa33b09f3f28f8ae1fb0e954), but since the Travis check is still The status check that runs on PRs, and has a badge in the README, I thought it best to fix it.

See the builds on the two commits in this branch to observe failing -> passing build.

Thanks for your work on this library!