### PR TITLE
docs: Link to docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A Github [CODEOWNERS](https://help.github.com/articles/about-codeowners/) answer sheet
 
-[Documentation](https://softprops.github.io/codeowners)
+[Documentation](https://docs.rs/codeowners)
 
 ## installation
 


### PR DESCRIPTION
* Change doc link in readme to docs.rs

The current link (https://softprops.github.io/codeowners) seems to be to a broken build of docs, and docs.rs seems to be a typical place to link to (I'm new to Rust but spot checked a few popular crates and they linked to docs.rs).